### PR TITLE
fix: deprecated File.exist? alias on newer ruby versions

### DIFF
--- a/lib/fastlane/plugin/universal_metadata/helper/universal_metadata_metadata.rb
+++ b/lib/fastlane/plugin/universal_metadata/helper/universal_metadata_metadata.rb
@@ -63,9 +63,9 @@ module Fastlane
       def self.getDescription(full, lang)
         folder = 'fastlane/universal-metadata/description/'
         file = full ? '/full_description.txt' : '/short_description.txt'
-        if File.exists?(folder + lang + file) then
+        if File.exist?(folder + lang + file) then
           return File.read(folder + lang + file)
-        elsif File.exists?(folder + 'default' + file) then
+        elsif File.exist?(folder + 'default' + file) then
           return File.read(folder + 'default' + file)
         else
           puts "Warning: " + lang + ' or default not found for description'
@@ -76,9 +76,9 @@ module Fastlane
       def self.getReleaseNotes(lang)
         folder = File.join('fastlane/universal-metadata/release-notes/')
 
-        if File.exists?(File.join(folder, lang + '.txt')) then
+        if File.exist?(File.join(folder, lang + '.txt')) then
           return File.read(File.join(folder, lang + '.txt'))
-        elsif File.exists?(File.join(folder, 'default.txt')) then
+        elsif File.exist?(File.join(folder, 'default.txt')) then
           return File.read(File.join(folder, 'default.txt'))
         else
           puts "Warning: " + lang + ' or default not found for release-notes'

--- a/lib/fastlane/plugin/universal_metadata/helper/universal_metadata_screenshots.rb
+++ b/lib/fastlane/plugin/universal_metadata/helper/universal_metadata_screenshots.rb
@@ -79,9 +79,9 @@ module Fastlane
       def self.getScreenshotFiles(lang)
         folder = File.join(Helper::UniversalMetadataConst.universal_metadata_folder, 'screenshots')
 
-        if File.exists?(File.join(folder, lang)) then
+        if File.exist?(File.join(folder, lang)) then
           # Nothing
-        elsif File.exists?(File.join(folder, 'default')) then
+        elsif File.exist?(File.join(folder, 'default')) then
           lang = 'default'
         else
           puts "Warning: " + lang + ' or default not found for screenshots'


### PR DESCRIPTION
Hello there!

I'm not sure if this project is still being maintained. We rely on your plugin at my company, but we've been encountering an issue when running it on newer ruby versions. The fix is easy enough:

Newer ruby versions (>=ruby-3.2) no longer have the File.exists? (with an s) alias pointing to File.exist? (without an s). This plugin fails on fastlane when using these newer versions. This fix replaces all instances of File.exists? with File.exist?

I hope you consider merging this fix! Thank you for writing this plugin in the first place :)